### PR TITLE
Change Json to longText

### DIFF
--- a/database/migrations/2017_12_13_171359_create_call_activities_table.php
+++ b/database/migrations/2017_12_13_171359_create_call_activities_table.php
@@ -21,7 +21,7 @@ class CreateCallActivitiesTable extends Migration
             $table->dateTime('start_date');
             $table->dateTime('end_date')->nullable();
             $table->uuid('uuid');
-            $table->json('details');
+            $table->longText('details');
             $table->longText('recording')->nullable();
         });
     }

--- a/database/migrations/2017_12_18_190018_create_custom_fields_table.php
+++ b/database/migrations/2017_12_18_190018_create_custom_fields_table.php
@@ -26,7 +26,7 @@ class CreateCustomFieldsTable extends Migration
             $table->enum('type', ['text', 'textarea', 'radio', 'checkbox', 'select', 'lookup', 'picklist', 'number', 'date', 'email', 'url', 'entity']);
             $table->string('entity_class')->nullable();
             $table->string('default')->nullable();
-            $table->json('values')->nullable();
+            $table->longText('values')->nullable();
             $table->boolean('required')->default(0);
             $table->boolean('protected')->default(0);
             $table->boolean('hidden')->default(0);

--- a/database/migrations/2018_01_03_170353_create_email_activities_table.php
+++ b/database/migrations/2018_01_03_170353_create_email_activities_table.php
@@ -19,7 +19,7 @@ class CreateEmailActivitiesTable extends Migration
             $table->increments('id');
             $table->timestamps();
             $table->text('content');
-            $table->json('details');
+            $table->longText('details');
         });
     }
 

--- a/database/migrations/2018_03_29_221058_create_sms_activities_table.php
+++ b/database/migrations/2018_03_29_221058_create_sms_activities_table.php
@@ -21,7 +21,7 @@ class CreateSmsActivitiesTable extends Migration
             $table->dateTime('start_date');
             $table->text('message');
             $table->uuid('uuid');
-            $table->json('details');
+            $table->longText('details');
         });
     }
 


### PR DESCRIPTION
JSON is an alias for LONGTEXT introduced for compatibility reasons with MySQL's JSON data type. MariaDB implements this as a LONGTEXT rather, as the JSON data type contradicts the SQL standard, and MariaDB's benchmarks indicate that performance is at least equivalent.

In order to ensure that a a valid json document is inserted, the JSON_VALID function can be used as a CHECK constraint.

See doc https://mariadb.com/kb/en/library/json-data-type/