### PR TITLE
Fix Headquarters > Pipeline > My Contacts translation key

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -67,7 +67,7 @@ return array(
     "due_date" => "Due Date",
     "enter.due_date" => "Enter due date",
     "my.profile" => "My Profile",
-    "my.contact" => "My Contact",
+    "my.contacts" => "My Contacts",
     "notifications" => "Notifications",
     "status" => "Status",
     "status_plural" => "Statuses",


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N 
| Automated tests included? | N
| Related user documentation PR URL | _N/A_
| Related developer documentation PR URL | _N/A_
| Issues addressed (#s or URLs) | #48
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fix translation key to accurately display **My Contacts** section label

![headquarters_pipeline_mycontacts_label](https://user-images.githubusercontent.com/918242/43372007-4157f0d4-936a-11e8-95b9-05203ac532c5.png)


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Visit `/headquarters` and look at **Pipeline**

#### Steps to test this PR:
1. Visit `/headquarters` and look at the **Pipeline > My Contacts** section

#### List deprecations along with the new alternative:
_N/A_

#### List backwards compatibility breaks:
_N/A_