### PR TITLE
A very dirty fix for the fatal error when trying to retrieve dynamic …

### DIFF
--- a/resources/views/react/index.blade.php
+++ b/resources/views/react/index.blade.php
@@ -33,7 +33,7 @@
 
         window.SAELOS_CONFIG = {
             APP_URL: "{{ env('APP_URL') }}",
-@foreach (config('settings') as $key => $value)
+@foreach (\App\Settings::where('user_id', '')->orWhereNull('user_id')->get() as $key => $value)
             {{ strtoupper($key) }}: "{{ $value }}",
 @endforeach
             BROADCAST_DRIVER: "{{ env('BROADCAST_DRIVER') }}"

--- a/resources/views/react/index.blade.php
+++ b/resources/views/react/index.blade.php
@@ -33,7 +33,7 @@
 
         window.SAELOS_CONFIG = {
             APP_URL: "{{ env('APP_URL') }}",
-@foreach (\App\Settings::where('user_id', '')->orWhereNull('user_id')->get() as $key => $value)
+@foreach (config("settings", []) as $key => $value)
             {{ strtoupper($key) }}: "{{ $value }}",
 @endforeach
             BROADCAST_DRIVER: "{{ env('BROADCAST_DRIVER') }}"


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? |  Y
| New feature? | 
| Automated tests included? |
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | #61
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
A very dirty fix for the fatal error when trying to retrieve dynamic settings during the Saelos load process. From https://github.com/saelos/saelos/blob/b6c866d703caf976ab8df5d84a13106319810366/app/Providers/AppServiceProvider.php#L62

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Visit Saelos URL and you'll see fatal error screen

#### Steps to test this PR:
1. Visit Saelos URL and make sure the login screen comes up instead of fatal error

#### List deprecations along with the new alternative:
_N/A_

#### List backwards compatibility breaks:
_N/A_